### PR TITLE
Support for read only root-filesystem for Kiali-Operator

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
             - ALL
         {{- end }}
         volumeMounts:
-        - mountPath: /tmp/ansible-operator/runner
-          name: runner
+        - mountPath: /tmp
+          name: tmp
         env:
         - name: WATCH_NAMESPACE
           value: {{ .Values.watchNamespace | default "\"\""  }}
@@ -120,7 +120,7 @@ spec:
         {{- toYaml .Values.resources | nindent 10 }}
         {{- end }}
       volumes:
-      - name: runner
+      - name: tmp
         emptyDir: {}
       affinity:
       {{- toYaml .Values.affinity | nindent 8 }}

--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+        - mountPath: /opt/ansible/.ansible/tmp
+          name: ansible-tmp
         env:
         - name: WATCH_NAMESPACE
           value: {{ .Values.watchNamespace | default "\"\""  }}
@@ -121,6 +123,8 @@ spec:
         {{- end }}
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: ansible-tmp
         emptyDir: {}
       affinity:
       {{- toYaml .Values.affinity | nindent 8 }}

--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -68,8 +68,6 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp
-        - mountPath: /opt/ansible/.ansible/tmp
-          name: ansible-tmp
         env:
         - name: WATCH_NAMESPACE
           value: {{ .Values.watchNamespace | default "\"\""  }}
@@ -85,6 +83,8 @@ spec:
           value: {{ .Values.allowAdHocKialiNamespace | quote }}
         - name: ALLOW_AD_HOC_KIALI_IMAGE
           value: {{ .Values.allowAdHocKialiImage | quote }}
+        - name: ANSIBLE_LOCAL_TEMP
+          value: {{ .Values.localAnsibleTmpPath | quote }}
 {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
         - name: ALLOW_AD_HOC_OSSMCONSOLE_IMAGE
           value: {{ .Values.allowAdHocOSSMConsoleImage | quote }}
@@ -123,8 +123,6 @@ spec:
         {{- end }}
       volumes:
       - name: tmp
-        emptyDir: {}
-      - name: ansible-tmp
         emptyDir: {}
       affinity:
       {{- toYaml .Values.affinity | nindent 8 }}

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -92,7 +92,7 @@ allowAllAccessibleNamespaces: true
 # localAnsibleTmpPath is the path of the local Ansible temp directory. This sets the ANSIBLE_LOCAL_TEMP variable which
 # in turn sets the DEFAULT_LOCAL_TMP configuration. An emptyDir is mounted to /tmp for the kiali-operator container.
 # Ansible needs write access on this directory so modifying it might have implications if read-only root filesystem is enabled.
-localAnsibleTmpPath: /tmp
+localAnsibleTmpPath: /tmp/ansible/tmp
 
 # accessibleNamespacesLabel restricts the namespaces that a user can add to the Kiali CR spec.deployment.accessible_namespaces.
 # This value is either an empty string (which disables this feature) or a label name with an optional label value

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -89,6 +89,11 @@ allowSecurityContextOverride: false
 # Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
 allowAllAccessibleNamespaces: true
 
+# localAnsibleTmpPath is the path of the local Ansible temp directory. This sets the ANSIBLE_LOCAL_TEMP variable which
+# in turn sets the DEFAULT_LOCAL_TMP configuration. An emptyDir is mounted to /tmp for the kiali-operator container.
+# Ansible needs write access on this directory so modifying it might have implications if read-only root filesystem is enabled.
+localAnsibleTmpPath: /tmp
+
 # accessibleNamespacesLabel restricts the namespaces that a user can add to the Kiali CR spec.deployment.accessible_namespaces.
 # This value is either an empty string (which disables this feature) or a label name with an optional label value
 # (e.g. "mylabel" or "mylabel=myvalue"). Only namespaces that have that label will be permitted in


### PR DESCRIPTION
1. Mounting emptyDir to /tmp.
2. Create env variable to set ANSIBLE_LOCAL_TEMP to control Ansible local temp directory and corresponding default in values file.
